### PR TITLE
Console.log styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,8 @@ _.extend(NodeMonkey.prototype, {
       overrideConsole: true,
       suppressOutput: true,
       saveOutput: true,
-      silent: false
+      silent: false,
+      clientSideStyles: true
     }, config || {});
 
     this.config.profiler = _.extend({
@@ -101,6 +102,7 @@ _.extend(NodeMonkey.prototype, {
     var stack = (new Error()).stack.toString().split('\n');
     var caller = stack[3]; // First line is just 'Error'
     var callerData = caller.match(/at (.*) \((.*):(.*):(.*)\)/);
+    var config = {clientSideStyles: this.config.clientSideStyles};
     if(!callerData) callerData = caller.match(/at ()(.*):(.*):(.*)/);
     callerData = {
       callerName: callerData[1],
@@ -112,7 +114,7 @@ _.extend(NodeMonkey.prototype, {
     // Send to open sockets if there is at least one, otherwise buffer
     var sendData = this.prepSendData(Array.prototype.slice.call(data));
 
-    var consoleData = {type: type, data: sendData, callerData: callerData};
+    var consoleData = {type: type, data: sendData, callerData: callerData, config: config};
     if(!this.iosrv || !_.keys(this.iosrv.sockets.sockets).length) {
       //this.clog('No clients - buffering');
       this.msgbuffer.push(consoleData);


### PR DESCRIPTION
Hey,
first of all: very cool and useful module!

I've built a small feature that allows styling the console.log output. The `stylize`-function converts ANSI escape sequences to `%c`-style formatting, which is supported both in Firebug and Chrome, but unfortunately not in Safari.

The example below uses one of the coloring modules like [tinycolor](https://npmjs.org/package/tinycolor).

Example:

``` javascript
console.log( 'This is italic blue,'.italic.blue + ' bold'.bold + '. A nice object: '.red + '%o' + '(%s)'.green +  'Substitute (%s)'.underline, {'Foo': 'bar'}, 'foo', 'bar');
```

looks like this in Firebug and Chrome:
![bildschirmfoto 2013-06-02 um 01 37 55](https://f.cloud.github.com/assets/1659320/595637/cf12e756-cb17-11e2-848b-4bf90b06dcba.png)
![bildschirmfoto 2013-06-02 um 01 38 22](https://f.cloud.github.com/assets/1659320/595638/cf599142-cb17-11e2-9944-1cfc87177332.png)

Just take a look at it and let me know what you think!

Cheers,
Johnny
