### PR TITLE
Error running `npm install`: syntax error and invalid comment in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "type": "git",
         "url": "https://github.com/jwarkentin/node-monkey.git"
     },
+    "//": "optimist and prompt are only used for utilities in the bin directory right now",
     "dependencies": {
         "async": "*",
         "cycle": ">= 1.0.3",
@@ -26,7 +27,6 @@
         "underscore.string": "*",
         "winston": "*",
 
-        "//": "These are only used for utilities in the bin directory right now",
         "optimist": "*",
         "prompt": "*"
     },


### PR DESCRIPTION
`npm install` from Git clone fails because of a syntax error (superfluous comma) in https://github.com/jwarkentin/node-monkey/blob/master/package.json#L31

After fixing that, `npm install` fails again, because of a comment: https://github.com/jwarkentin/node-monkey/blob/master/package.json#L29 in a place where it is not allowed, please see https://github.com/npm/npm/issues/4482#issuecomment-32289053 for more information.
