### PR TITLE
Fix regression introduced with colors branch

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ _.extend(NodeMonkey.prototype, {
     var stack = (new Error()).stack.toString().split('\n');
     var caller = stack[3]; // First line is just 'Error'
     var callerData = caller.match(/at (.*) \((.*):(.*):(.*)\)/);
-    var config = {convertStyles: this.config.clientSideStyles};
+    var config = {convertStyles: this.config.convertStyles};
     if(!callerData) callerData = caller.match(/at ()(.*):(.*):(.*)/);
     callerData = {
       callerName: callerData[1],


### PR DESCRIPTION
[Ref. colors regression](https://github.com/jwarkentin/node-monkey/commit/0bc8402947150c5628d457b5f089234de6d85e30#diff-168726dbe96b3ce427e7fedce31bb0bcR105).

The server-side config. property never got updated to match the new name-scheme.
Therefore, when the client receives the data, it does not contain the necessary config. property to allow the client to colorize the log.
